### PR TITLE
Update triggers for gh action

### DIFF
--- a/.github/workflows/stageTestAction.yml
+++ b/.github/workflows/stageTestAction.yml
@@ -1,14 +1,10 @@
 name: Run playwright tests against stage
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-  push:
-    branches:
-      - main
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   schedule:
     - cron: "0 0 * * *" # This cron expression runs the action every 24 hours at midnight UTC
+  workflow_dispatch:
 
 concurrency:
   group: integration-group


### PR DESCRIPTION
Move to `pull_request_target` to allow using secrets and add manual trigger.