### PR TITLE
Chore: add pg package, skip local-only tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@playwright/test": "^1.49.1",
     "@currents/playwright": "^1.9.4",
     "@types/node": "^22.9.0",
-    "dayjs": "^1.11.13"
+    "dayjs": "^1.11.13",
+    "pg": "^8.14.1"
   },
   "dependencies": {
     "dotenv": "^16.4.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
         { name: 'setup', testMatch: /.*\.setup\.ts/ },
         {
             name: 'chromium',
-            grepInvert: !!process.env.PROD ? [/preview-only/, /switch-to-preview/] : [/switch-to-preview/],
+            grepInvert: !!process.env.PROD ? [/preview-only/, /switch-to-preview/, /local-only/] : [/switch-to-preview/, /local-only/],
             use: {
                 ...devices['Desktop Chrome'],
                 storageState: `.auth/${process.env.USER1USERNAME}.json`,


### PR DESCRIPTION
* The pg package was added to the backend repo's playwright tests, we need it here too or the integration tests will fail
* Adds filter to skip tests with a local-only tag